### PR TITLE
Split dockerfile to multistage

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,8 +1,21 @@
+FROM alpine:3.12 AS build
+
+RUN apk --no-cache add build-base go
+
+ADD . /go/src/github.com/google/systemd_exporter
+WORKDIR /go/src/github.com/google/systemd_exporter
+
+ENV GOROOT /usr/lib/go
+ENV GOPATH /go
+RUN make build
+
 FROM alpine:3.12
 MAINTAINER dashpole@google.com
 
-COPY systemd_exporter /usr/bin/systemd_exporter
+RUN apk --no-cache add libc6-compat
+
+ADD systemd_exporter /usr/bin/systemd_exporter
 
 EXPOSE 8080
 
-ENTRYPOINT ["/usr/bin/systemd_exporter", "-logtostderr"]
+ENTRYPOINT ["/usr/bin/systemd_exporter", "--logtostderr"]


### PR DESCRIPTION
It needed some packages to be able to run, and performing the build in the dockerfile will remove environmental problems.